### PR TITLE
Output Z3 model

### DIFF
--- a/libstarling/ExprEquiv.fs
+++ b/libstarling/ExprEquiv.fs
@@ -49,7 +49,7 @@ let equivHolds
     use ctx = new Z3.Context ()
     let term = ctx.MkNot (e toVar ctx)
     match (Run.runTerm ctx term) with
-    | Z3.Status.UNSATISFIABLE -> true
+    | (Z3.Status.UNSATISFIABLE, _) -> true
     | _ -> false
 
 /// <summary>

--- a/libstarling/Pretty.fs
+++ b/libstarling/Pretty.fs
@@ -168,6 +168,8 @@ let printUnstyled = printState { Level = 0; CurrentStyle = None; UseStyles = fal
 let vsep xs = VSep(xs, Nop)
 let hsepStr s c = HSep(c, String s)
 
+let starsep xs = HSep(xs, String "*")
+
 /// Horizontally joins a list of commands with no separator.
 let hjoin c = HSep(c, Nop)
 /// Horizontally separates a list of commands with a space separator.

--- a/libstarling/Var.fs
+++ b/libstarling/Var.fs
@@ -155,16 +155,13 @@ let markVar (v: Var) : MarkedVar =
         (Regex "V(.+)INT(.+)", (fun (m: Match) -> Intermediate (BigInteger.Parse(m.Groups[2].Value), m.Groups[1].Value)));
     ]
 
-    let vars = [
-        for (r, b) in regex_builders do
-            let matches = r.Matches(v)
-            if matches.Count > 0 then
-                yield b matches[0]
-    ]
-
-    if vars.Length <> 1
-        then failwith "unreachable? unknown marked var format"
-        else vars[0]
+    regex_builders
+    |> Seq.collect (
+        fun (r, b) ->
+            r.Matches(v)
+            |> Seq.map b
+    )
+    |> Seq.item 0
 
 
 module VarMap =

--- a/libstarling/Var.fs
+++ b/libstarling/Var.fs
@@ -3,6 +3,9 @@
 /// </summary>
 module Starling.Core.Var
 
+open System.Numerics
+open System.Text.RegularExpressions
+
 open Chessie.ErrorHandling
 
 open Starling.Utils
@@ -139,6 +142,29 @@ let unmarkVar : MarkedVar -> Var =
     | After c -> sprintf "V%sAFTER" c
     | Intermediate(i, c) -> sprintf "V%sINT%A" c i
     | Goal(i, c) -> sprintf "V%sGOAL%A" c i
+
+
+/// <summary>
+///     Converts a <c>Var</c> to a <c>MarkedVar</c>, un-munging its name.
+/// </summary>
+let markVar (v: Var) : MarkedVar =
+    let regex_builders = [
+        (Regex "V(.+)BEFORE", (fun (m: Match) -> Before(m.Groups[1].Value)));
+        (Regex "V(.+)AFTER", (fun (m: Match) -> After(m.Groups[1].Value)));
+        (Regex "V(.+)GOAL(.+)", (fun (m: Match) -> Goal (BigInteger.Parse(m.Groups[2].Value), m.Groups[1].Value)));
+        (Regex "V(.+)INT(.+)", (fun (m: Match) -> Intermediate (BigInteger.Parse(m.Groups[2].Value), m.Groups[1].Value)));
+    ]
+
+    let vars = [
+        for (r, b) in regex_builders do
+            let matches = r.Matches(v)
+            if matches.Count > 0 then
+                yield b matches[0]
+    ]
+
+    if vars.Length <> 1
+        then failwith "unreachable? unknown marked var format"
+        else vars[0]
 
 
 module VarMap =

--- a/libstarling/Z3.fs
+++ b/libstarling/Z3.fs
@@ -163,10 +163,6 @@ module Run =
         let s = solver.Check ()
         let p =
             match s with
-            | Z3.Status.SATISFIABLE ->
-                try
-                    Some (solver.get_Model ())
-                with
-                | :? Z3.Z3Exception -> None
+            | Z3.Status.SATISFIABLE -> Some solver.Model
             | _ -> None
         (s, p)

--- a/libstarling/Z3.fs
+++ b/libstarling/Z3.fs
@@ -150,9 +150,23 @@ module Expr =
 /// </summary>
 module Run =
     /// <summary>
+    ///     A Z3 Proof
+    /// </summary>
+    type ZProof = Z3.Model
+
+    /// <summary>
     ///     Runs Z3 on a single Boolean Z3 expression.
     /// </summary>
-    let runTerm (ctx: Z3.Context) term =
+    let runTerm (ctx: Z3.Context) term : Z3.Status * ZProof option =
         let solver = ctx.MkSimpleSolver ()
         solver.Assert [| term |]
-        solver.Check ()
+        let s = solver.Check ()
+        let p =
+            match s with
+            | Z3.Status.SATISFIABLE ->
+                try
+                    Some (solver.get_Model ())
+                with
+                | :? Z3.Z3Exception -> None
+            | _ -> None
+        (s, p)

--- a/libstarling/Z3Backend.fs
+++ b/libstarling/Z3Backend.fs
@@ -285,7 +285,7 @@ module Pretty =
                     if not (f.Arity.Equals(0u))
                         then failwith "Unknown Z3 output model format, expected zero arity declarations only."
 
-                    let name = printMarkedVar <| markVar $"{f.get_Name()}";
+                    let name = printMarkedVar <| markVar $"{f.Name}";
                     assert (f.Arity.Equals(0u));
                     let body = String $"{p.ConstInterp(f)}";
                     yield cmdSexpr "=" [name; body]
@@ -416,10 +416,7 @@ module Pretty =
 let runZ3OnModel (shouldUseRealsForInts : bool)
   (model : Model<SymProofTerm, FuncDefiner<BoolExpr<Sym<Var>> option>>)
   : ZModel =
-    let cfg = Dictionary<string,string>();
-    cfg.Add("proof", "true")
-    cfg.Add("unsat_core", "true")
-    use ctx = new Z3.Context (cfg)
+    use ctx = new Z3.Context ()
 
     // Save us from having to supply all of these arguments every time.
     // TODO(CaptainHayashi): subtypes?

--- a/libstarling/Z3Backend.fs
+++ b/libstarling/Z3Backend.fs
@@ -15,8 +15,6 @@
 /// </summary>
 module Starling.Backends.Z3
 
-open System.Collections.Generic
-
 open Microsoft
 open Starling
 open Starling.Utils

--- a/starling/Program.fs
+++ b/starling/Program.fs
@@ -231,6 +231,11 @@ module private ViewConfig =
               ("show-backend-translation",
                ("Emit the backend translations in proof failures.",
                  updateZ3 (fun ps -> { ps with ShowBackendTranslation = true })))
+              ("show-model",
+                ("Emit the Z3 output model in proof failures.",
+                updateZ3 (fun ps ->
+                    { ps with
+                        ShowModel = true })))
               ("list",
                ("Lists all view options.",
                 fun ps ->


### PR DESCRIPTION
Query for the Z3 Model on a proof failure, and if `-V show-model` is passed, then dump the smtlib countermodel into the output.

The Z3 model is parsed and pretty-printed, with some checks that the model is the shape expected:
```
    release_strong_C006_006 fail:
        Could not prove action: ASSUME last
        under weakest precondition: ((before last) -> WeakRef())*iter[(- (goal 119 n) 1 1)]((and
            (> (goal 119 n) 1)
            (> (goal 119 n) 2)
        ) -> WeakRef())
        establishes: iter[(goal 119 n)]WeakRef()
        countermodel: (model
            (= (before closed) false)
            (= (goal 119 n) 2)
            (= (before strong) 0)
            (= (before deallocated) false)
            (= (before weak) 1)
            (= (before last) true)
            (= (before destructed) false)
        )
```